### PR TITLE
SBP M2 review: inject address mapping logic via evm pallet's config trait

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1390,6 +1390,12 @@ impl<T: Config<I>, I: 'static> Currency<T::AccountId> for Pallet<T, I> where
 		if amount.is_zero() { return Ok(()) }
 		let min_balance = Self::account(who).frozen(reasons.into());
 		ensure!(new_balance >= min_balance, Error::<T, I>::LiquidityRestrictions);
+
+		// SBP M2 review: You may want to extract this logic in a custom CurrencyAdapter
+		// (to be used on the Transaction Payment pallet's OnChargeTransaction param)
+		// This would be implemented in the withdraw_fee function, accessing state from
+		// a custom pallet (e.g. account_limits), before calling the Currency withdraw function.
+		// This would obviate the need for maintaining a local fork of the FRAME balances pallet ;)
 		match reasons {
 			WithdrawReasons::TRANSFER => {
 				if amount.is_zero() { return Ok(()) }

--- a/pallets/validator-set/src/lib.rs
+++ b/pallets/validator-set/src/lib.rs
@@ -8,6 +8,12 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// SBP M2 review: Just want to emphasize that this pallet is an example of an approach
+// for handling a dynamic validator set, but this has not gone through the same thorough
+// quality review process that the FRAME library has.
+// As stated in the README: this code not audited and reviewed for production use cases.
+// You can expect bugs and security vulnerabilities. Do not use it as-is in real applications.
+
 use sp_std::prelude::*;
 use frame_support::{
 	StorageValue,


### PR DESCRIPTION
This obviates the need for adding a dependency to `pallet-account-service` in a local fork of Frontier.